### PR TITLE
Minor changes for Login, SignUp, and Update User

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserGetDTO.java
@@ -17,6 +17,7 @@ public class UserGetDTO {
   private String role;
   private String token;
   private Game gameRoom;
+  private String username;
 
   // getters
 
@@ -60,6 +61,10 @@ public class UserGetDTO {
     return role;
   }
 
+  public String getUsername() {
+    return username;
+  }
+
   // setters
 
   public void setToken(String token){
@@ -100,5 +105,9 @@ public class UserGetDTO {
 
   public void setRole(String role) {
     this.role = role;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
   }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserPostDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/UserPostDTO.java
@@ -32,6 +32,10 @@ public class UserPostDTO {
     this.avatarId = avatarId;
   }
 
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
   // getters
 
   public String getNickname() {
@@ -56,10 +60,6 @@ public class UserPostDTO {
 
   public String getUsername() {
     return username;
-  }
-
-  public void setUsername(String username) {
-    this.username = username;
   }
   
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
@@ -56,6 +56,7 @@ public interface DTOMapper {
   @Mapping(source = "role", target = "role")
   @Mapping(source = "token", target = "token")
   @Mapping(source = "gameRoom", target = "gameRoom")
+  @Mapping(source = "username", target = "username")
   UserGetDTO convertEntityToUserGetDTO(User user);
 
   @Mapping(source = "admin", target = "admin")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
@@ -74,15 +74,14 @@ public class UserService {
         throw new ResponseStatusException(HttpStatus.CONFLICT, "Username already exists.");
     }
     user.setPersistent(true);
-    user.setNickname(null);
     user.setToken(UUID.randomUUID().toString());
-    user.setStatus(UserStatus.OFFLINE);
     user.setCreationDate(LocalDate.now());
-    // more accurate to set their status to OFFLINE upon signup and then change it to ONLINE when they log in successfully.
-    //user.setStatus(UserStatus.ONLINE);
+    user.setStatus(UserStatus.ONLINE);
 
+    user = userRepository.save(user);
+    userRepository.flush();
 
-    return userRepository.save(user);
+    return user;
   }
 
   // persistent user sign in
@@ -112,7 +111,8 @@ public class UserService {
     userToLogin.setStatus(UserStatus.ONLINE);
 
     // Save the updated user (with token and status) to the database
-    userRepository.save(userToLogin);
+    userToLogin = userRepository.save(userToLogin);
+    userRepository.flush();
 
     // Return the authenticated user
     return userToLogin;
@@ -180,8 +180,8 @@ public class UserService {
     if (userInput.getAvatarId() != null){
       oldUser.setAvatarId(userInput.getAvatarId());
     }
-    if (userInput.getEmail() != null){
-      oldUser.setEmail(userInput.getEmail());
+    if (userInput.getUsername() != null){
+      oldUser.setUsername(userInput.getUsername());
     }
     if (userInput.getPassword() != null){
       oldUser.setPassword(userInput.getPassword());


### PR DESCRIPTION
added username to UserGetDTO, modified signUpUser() to allow nickname, changed signUpUser() and loginUser() to save with flush, replaced email with username in updateUser(), changes for client-side functionality #36, #37, #41

Reasoning
- username in UserGetDTO to show and change username in profile when user is persistent
- allowed for nickname in signUpUser so that default nickname will just be equal to username for persistent users, can still be changed in profile or before game
- changed status to online in signUpUser because user is directly in after sign up, no need to login after sign up
- used flush() to align with createUser, guarantees saving of user
- replaced email with username in updateUser because email is not used client side, while username should be changeable from profile for persistent users